### PR TITLE
flake: drop flake-parts dependency

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1762040540,
-        "narHash": "sha256-z5PlZ47j50VNF3R+IMS9LmzI5fYRGY/Z5O5tol1c9I4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "0010412d62a25d959151790968765a70c436598b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1762286042,
@@ -35,24 +17,8 @@
         "url": "https://github.com/NixOS/nixpkgs"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,19 +3,22 @@
 
   inputs = {
     nixpkgs.url = "git+https://github.com/NixOS/nixpkgs?shallow=1&ref=nixpkgs-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs = inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } ({ ... }: {
+  outputs =
+    { self, nixpkgs }:
+    let
       systems = [
         "x86_64-linux"
         "aarch64-linux"
         "x86_64-darwin"
         "aarch64-darwin"
       ];
-      perSystem = { pkgs, ... }: {
-        packages.default = pkgs.python3.pkgs.callPackage ./default.nix { };
-      };
-    });
+      eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = eachSystem (pkgs: {
+        default = pkgs.python3.pkgs.callPackage ./default.nix { };
+      });
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -20,5 +20,9 @@
       packages = eachSystem (pkgs: {
         default = pkgs.python3.pkgs.callPackage ./default.nix { };
       });
+
+      checks = eachSystem (pkgs: {
+        package-default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      });
     };
 }


### PR DESCRIPTION
This flake only used flake-parts for a trivial perSystem mapping.
Replace it with nixpkgs.lib.genAttrs to remove an unnecessary input
and reduce lock file churn.
